### PR TITLE
Steps

### DIFF
--- a/source/_patterns/00-protons/_01-global.scss
+++ b/source/_patterns/00-protons/_01-global.scss
@@ -1,4 +1,22 @@
-// COover image with bleed
+
+// Step
+@mixin step {
+  @include custom-counter();
+  @include custom-counter-line();
+  @include u-measure('5');
+  @include u-line-height('body', 4);
+  padding-left: 3.5rem;
+
+  // CODEREVIEW
+  // These are redundant with the @mixin unstyled-list(), 
+  // but is requeried if we want this Molecule to behave consistently 
+  // when used as a standalone component.
+  margin-bottom: 0;
+  list-style: none;
+}
+
+
+// Cover image with bleed
 @mixin cover-image {
   position: absolute;
   top: 0;

--- a/source/_patterns/00-protons/_01-global.scss
+++ b/source/_patterns/00-protons/_01-global.scss
@@ -6,13 +6,6 @@
   @include u-measure('5');
   @include u-line-height('body', 4);
   padding-left: 3.5rem;
-
-  // CODEREVIEW
-  // These are redundant with the @mixin unstyled-list(), 
-  // but is requeried if we want this Molecule to behave consistently 
-  // when used as a standalone component.
-  margin-bottom: 0;
-  list-style: none;
 }
 
 

--- a/source/_patterns/00-protons/_01-global.scss
+++ b/source/_patterns/00-protons/_01-global.scss
@@ -1,14 +1,3 @@
-
-// Step
-@mixin step {
-  @include custom-counter();
-  @include custom-counter-line();
-  @include u-measure('5');
-  @include u-line-height('body', 4);
-  padding-left: 3.5rem;
-}
-
-
 // Cover image with bleed
 @mixin cover-image {
   position: absolute;

--- a/source/_patterns/02-molecules/01-blocks/04-step/01-step.json
+++ b/source/_patterns/02-molecules/01-blocks/04-step/01-step.json
@@ -1,0 +1,5 @@
+{
+  "title": "Plaholder Title",
+  "excerpt": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vel quis quasi sit consequatur asperiores rem cum inventore, doloribus assumenda voluptatibus aperiam iure fugit ratione culpa possimus enim rerum autem voluptatem!",
+  "read_more_link": "check it out"
+}

--- a/source/_patterns/02-molecules/01-blocks/04-step/01-step.twig
+++ b/source/_patterns/02-molecules/01-blocks/04-step/01-step.twig
@@ -1,0 +1,7 @@
+<li class="jcc-step">
+  <h3 class="jcc-step__title">{{ title }}</h3>
+  <p class="jcc-step__excerpt">{{ excerpt }}</p>
+  {% if read_more_link is not empty %}
+  <a href="#" class="jcc-step__toggle">{{ read_more_link }}</a>
+  {% endif %}
+</li>

--- a/source/_patterns/02-molecules/01-blocks/04-step/_01-step.scss
+++ b/source/_patterns/02-molecules/01-blocks/04-step/_01-step.scss
@@ -1,11 +1,11 @@
 @import "../../../00-protons/01-global";
 
 .jcc-step {
-  @include step();
-  // CODEREVIEW
-  // These are redundant with the @mixin unstyled-list(), 
-  // but is requeried if we want this Molecule to behave consistently 
-  // when used as a standalone component.
+  @include custom-counter();
+  @include custom-counter-line();
+  @include u-measure('5');
+  @include u-line-height('body', 4);
+  padding-left: 3.5rem;
   margin-bottom: 0;
   list-style: none;
 }

--- a/source/_patterns/02-molecules/01-blocks/04-step/_01-step.scss
+++ b/source/_patterns/02-molecules/01-blocks/04-step/_01-step.scss
@@ -1,0 +1,5 @@
+@import "../../../00-protons/01-global";
+
+.jcc-step {
+  @include step();
+}

--- a/source/_patterns/02-molecules/01-blocks/04-step/_01-step.scss
+++ b/source/_patterns/02-molecules/01-blocks/04-step/_01-step.scss
@@ -2,4 +2,10 @@
 
 .jcc-step {
   @include step();
+  // CODEREVIEW
+  // These are redundant with the @mixin unstyled-list(), 
+  // but is requeried if we want this Molecule to behave consistently 
+  // when used as a standalone component.
+  margin-bottom: 0;
+  list-style: none;
 }

--- a/source/_patterns/03-organisms/01-sections/03-steps/01-steps.twig
+++ b/source/_patterns/03-organisms/01-sections/03-steps/01-steps.twig
@@ -2,15 +2,10 @@
   <div class="jcc-steps-section__container">
     {% include 'molecules-header-group' %}
     <ul class="jcc-steps">
-      
       {% for step in steps %}
-      <li class="jcc-steps__step">
-        <h3 class="jcc-step__title">{{ step.title }}</h3>
-        <p class="jcc-step__excerpt">{{ step.excerpt }}</p>
-        {% if step.read_more_link is not empty %}
-        <a href="#" class="jcc-step__toggle">{{ step.read_more_link }}</a>
-        {% endif %}
-      </li>
+
+      {% include "molecules-step" %}
+        
       {% endfor %}
     </ul>
   </div>

--- a/source/_patterns/03-organisms/01-sections/03-steps/01-steps.twig
+++ b/source/_patterns/03-organisms/01-sections/03-steps/01-steps.twig
@@ -1,6 +1,8 @@
 <div class="jcc-steps-section jcc-steps-section--{{ background_variant }}">
   <div class="jcc-steps-section__container">
+    
     {% include 'molecules-header-group' %}
+    
     <ul class="jcc-steps">
       {% for step in steps %}
 

--- a/source/_patterns/03-organisms/01-sections/03-steps/01-steps.twig
+++ b/source/_patterns/03-organisms/01-sections/03-steps/01-steps.twig
@@ -4,7 +4,11 @@
     <ul class="jcc-steps">
       {% for step in steps %}
 
-      {% include "molecules-step" %}
+      {% include "molecules-step" with {
+        title: step.title,
+        excerpt: step.excerpt,
+        read_more_link: step.read_more_link
+      } %}
         
       {% endfor %}
     </ul>

--- a/source/_patterns/03-organisms/01-sections/03-steps/01-steps.twig
+++ b/source/_patterns/03-organisms/01-sections/03-steps/01-steps.twig
@@ -2,6 +2,7 @@
   <div class="jcc-steps-section__container">
     {% include 'molecules-header-group' %}
     <ul class="jcc-steps">
+      
       {% for step in steps %}
       <li class="jcc-steps__step">
         <h3 class="jcc-step__title">{{ step.title }}</h3>

--- a/source/_patterns/03-organisms/01-sections/03-steps/_01_steps.scss
+++ b/source/_patterns/03-organisms/01-sections/03-steps/_01_steps.scss
@@ -11,21 +11,13 @@
 
 .jcc-steps-section--has-background-color {
   @include u-padding-top(6);
-  @include u-bg("base-lightest");
+  @include u-bg('base-lightest');
 }
 
 .jcc-steps-section__container {
-  @include grid-container("widescreen");
+  @include grid-container('widescreen');
 }
 
 .jcc-steps {
   @include unstyled-list();
-}
-
-.jcc-steps__step {
-  @include custom-counter();
-  @include custom-counter-line();
-  @include u-measure("5");
-  @include u-line-height("body", 4);
-  padding-left: 3.5rem;
 }


### PR DESCRIPTION
1. Created the step mixin at global.scss
2. Abstracted the Step component in its own molecule.
3. Left a comment on `step.scss` about the redundancy of 2 lines of css, in order to make it consistent when used as a standalone component.
4. the `step` molecule is added to the `steps` organism via a twig `@include`
5. data for each step is still coming directly from the `step.json` file, and not contextualized to pull from `steps.step`. This is something I need to look in the docs for pattern lab. 
6. I'm still confused on why we are abstracting the styles of the `step` molecule into a mixin.
