### PR TITLE
Provide the Ability to Easily Debug the Pattern Lab

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 public/
+config/

--- a/composer.json
+++ b/composer.json
@@ -1,75 +1,79 @@
 {
-    "name":             "pattern-lab/edition-drupal-standard",
-    "description":      "Standard Edition of Pattern Lab for Drupal.",
-    "keywords":         ["pattern lab", "drupal"],
-    "homepage":         "http://patternlab.io",
-    "license":          "GPL-2.0+",
-    "type":             "project",
-    "authors": [
-        {
-            "name":         "Dave Olsen",
-            "email":        "dmolsen@gmail.com",
-            "homepage":     "http://dmolsen.com",
-            "role":         "Lead Developer"
-        },
-        {
-            "name":         "Evan Lovely",
-            "homepage":     "http://evanlovely.com",
-            "role":         "Developer"
-        }
-    ],
-    "support": {
-        "issues":         "https://github.com/pattern-lab/edition-drupal-standard/issues",
-        "wiki":           "http://patternlab.io/docs/",
-        "source":         "https://github.com/pattern-lab/edition-drupal-standard/releases"
+  "name": "pattern-lab/edition-drupal-standard",
+  "description": "Standard Edition of Pattern Lab for Drupal.",
+  "keywords": [
+    "pattern lab",
+    "drupal"
+  ],
+  "homepage": "http://patternlab.io",
+  "license": "GPL-2.0+",
+  "type": "project",
+  "authors": [
+    {
+      "name": "Dave Olsen",
+      "email": "dmolsen@gmail.com",
+      "homepage": "http://dmolsen.com",
+      "role": "Lead Developer"
     },
-    "autoload": {
-        "psr-0": {
-            "PatternLab":   "core/src/"
-        }
-    },
-    "require": {
-        "php": ">=5.5.9",
-        "pattern-lab/core": "^2.7.0",
-        "pattern-lab/patternengine-twig": "^2.0.0",
-        "pattern-lab/styleguidekit-twig-default": "^3.0.0",
-        "pattern-lab/drupal-twig-components": "^2.0.0",
-        "aleksip/plugin-data-transform": "^1.0.0"
-    },
-    "scripts": {
-        "server": "php core/console --server",
-        "generate": "php core/console --generate",
-        "watch": "php core/console --watch",
-        "start": "php core/console --server  --quiet & php core/console --watch",
-        "post-install-cmd": [
-          "PatternLab\\Installer::postInstallCmd"
-        ],
-        "post-update-cmd": [
-          "PatternLab\\Installer::postUpdateCmd"
-        ],
-        "post-root-package-install": [
-          "PatternLab\\Installer::setProjectInstall",
-          "PatternLab\\Installer::getSuggestedStarterKits",
-          "PatternLab\\Installer::getConfigOverrides"
-        ],
-        "post-package-install": [
-          "PatternLab\\Installer::postPackageInstall"
-        ],
-        "post-package-update": [
-          "PatternLab\\Installer::postPackageUpdate"
-        ],
-        "pre-package-uninstall": [
-          "PatternLab\\Installer::prePackageUninstall"
-        ]
-      },
-    "extra": {
-        "patternlab": {
-            "starterKitSuggestions": [
-                "pattern-lab/starterkit-twig-demo",
-                "pattern-lab/starterkit-twig-drupal-minimal",
-                "aleksip/starterkit-shila-drupal-theme",
-                "forumone/starterkit-twig-drupal-gesso"
-            ]
-        }
+    {
+      "name": "Evan Lovely",
+      "homepage": "http://evanlovely.com",
+      "role": "Developer"
     }
+  ],
+  "support": {
+    "issues": "https://github.com/pattern-lab/edition-drupal-standard/issues",
+    "wiki": "http://patternlab.io/docs/",
+    "source": "https://github.com/pattern-lab/edition-drupal-standard/releases"
+  },
+  "autoload": {
+    "psr-0": {
+      "PatternLab": "core/src/"
+    }
+  },
+  "require": {
+    "php": ">=5.5.9",
+    "pattern-lab/core": "^2.7.0",
+    "pattern-lab/patternengine-twig": "^2.0.0",
+    "pattern-lab/styleguidekit-twig-default": "^3.0.0",
+    "pattern-lab/drupal-twig-components": "^2.0.0",
+    "aleksip/plugin-data-transform": "^1.0.0",
+    "ajgl/breakpoint-twig-extension": "^0.3.4"
+  },
+  "scripts": {
+    "server": "php core/console --server",
+    "generate": "php core/console --generate",
+    "watch": "php core/console --watch",
+    "start": "php core/console --server  --quiet & php core/console --watch",
+    "post-install-cmd": [
+      "PatternLab\\Installer::postInstallCmd"
+    ],
+    "post-update-cmd": [
+      "PatternLab\\Installer::postUpdateCmd"
+    ],
+    "post-root-package-install": [
+      "PatternLab\\Installer::setProjectInstall",
+      "PatternLab\\Installer::getSuggestedStarterKits",
+      "PatternLab\\Installer::getConfigOverrides"
+    ],
+    "post-package-install": [
+      "PatternLab\\Installer::postPackageInstall"
+    ],
+    "post-package-update": [
+      "PatternLab\\Installer::postPackageUpdate"
+    ],
+    "pre-package-uninstall": [
+      "PatternLab\\Installer::prePackageUninstall"
+    ]
+  },
+  "extra": {
+    "patternlab": {
+      "starterKitSuggestions": [
+        "pattern-lab/starterkit-twig-demo",
+        "pattern-lab/starterkit-twig-drupal-minimal",
+        "aleksip/starterkit-shila-drupal-theme",
+        "forumone/starterkit-twig-drupal-gesso"
+      ]
+    }
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,68 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76884f03f8bf5343e9f7699763977778",
+    "content-hash": "f5f1a083cde0ec5467e26d6c2ee15c66",
     "packages": [
+        {
+            "name": "ajgl/breakpoint-twig-extension",
+            "version": "0.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ajgarlag/AjglBreakpointTwigExtension.git",
+                "reference": "13ee39406dc3d959c5704b462a3dbc3cbf088f16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ajgarlag/AjglBreakpointTwigExtension/zipball/13ee39406dc3d959c5704b462a3dbc3cbf088f16",
+                "reference": "13ee39406dc3d959c5704b462a3dbc3cbf088f16",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "twig/twig": "^1.14|^2.0"
+            },
+            "require-dev": {
+                "symfony/framework-bundle": "^2.7|^3.2|^4.1",
+                "symfony/phpunit-bridge": "^3.4|^4.1",
+                "symfony/twig-bundle": "^2.7|^3.2|^4.1"
+            },
+            "suggest": {
+                "ext-xdebug": "The Xdebug extension is required for the breakpoint to work",
+                "symfony/framework-bundle": "The framework bundle to integrate the extension into Symfony",
+                "symfony/twig-bundle": "The twig bundle to integrate the extension into Symfony"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ajgl\\Twig\\Extension\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio J. García Lagar",
+                    "email": "aj@garcialagar.es",
+                    "homepage": "http://aj.garcialagar.es",
+                    "role": "developer"
+                }
+            ],
+            "description": "Twig extension to set breakpoints",
+            "homepage": "https://github.com/ajgarlag/AjglBreakpointTwigExtension",
+            "keywords": [
+                "Xdebug",
+                "breakpoint",
+                "twig"
+            ],
+            "time": "2019-04-10T11:41:26+00:00"
+        },
         {
             "name": "alchemy/zippy",
             "version": "0.3.5",

--- a/config/config.yml
+++ b/config/config.yml
@@ -29,10 +29,11 @@ styleguideKitPath: vendor/pattern-lab/styleguidekit-twig-default
 lineageMatch: '{%([ ]+)?(?:include|extends|embed)( |\()[&quot;\&#039;]([\/.@A-Za-z0-9-_]+)[&quot;\&#039;]([\s\S+]*?)%}'
 lineageMatchKey: 3
 patternExtension: twig
-twigDebug: false
+twigDebug: true
 twigAutoescape: false
 twigDefaultDateFormat: ""
 twigDefaultIntervalFormat: ""
+twigExtensions: - '\Ajgl\Twig\Extension\BreakpointExtension'
 twigMacroExt: macro.twig
 twigFilterExt: filter.php
 twigFunctionExt: function.php

--- a/config/config.yml
+++ b/config/config.yml
@@ -33,7 +33,8 @@ twigDebug: true
 twigAutoescape: false
 twigDefaultDateFormat: ""
 twigDefaultIntervalFormat: ""
-twigExtensions: - '\Ajgl\Twig\Extension\BreakpointExtension'
+twigExtensions: 
+  - '\Ajgl\Twig\Extension\BreakpointExtension'
 twigMacroExt: macro.twig
 twigFilterExt: filter.php
 twigFunctionExt: function.php


### PR DESCRIPTION
**IMPORTANT NOTES**:  

- [x] Husky is causing malformed YAML. See my note in the code of this PR.  We need to make it either format YML correctly or exclude YML files.
- Run `composer install` locally after pulling this PR.

This PR does two things:

## 1.  Enables usage of [`dump()`](https://twig.symfony.com/doc/1.x/functions/dump.html).
This PR turns on Twig debug mode, which allows you to use [dump()](https://twig.symfony.com/doc/1.x/functions/dump.html), which will print the available variables to the screen. Example usage:

```twig
{# All variables #}
<pre>{{ dump() }} <pre>

{# Specific variable #}
<pre>{{ dump(something) }} <pre>
```

<img width="1279" alt="dump-in-accordion" src="https://user-images.githubusercontent.com/60979/66218122-8f968500-e696-11e9-9816-e716c7d0963a.png">

## 2. Enables PHP debugging with xDebug in Twig files with `breakpoint()`
There's a lot more involved to setting this one up, and it varies depending on OS and editor, but it's another great option.  Example usage:

```twig
{# Anywhere in a Twig template #}
{{ breakpoint() }}
```

<img width="1348" alt="xdebug" src="https://user-images.githubusercontent.com/60979/66219973-257fdf00-e69a-11e9-9945-049ba8fbcad8.png">
