### PR TITLE
Markup for the Expandable Item and Expandable Section Components

### DIFF
--- a/source/_patterns/02-molecules/interactive/expandable-item/_expandable-item.scss
+++ b/source/_patterns/02-molecules/interactive/expandable-item/_expandable-item.scss
@@ -1,0 +1,45 @@
+.jcc-expandable-item {
+  @include u-bg('base-lightest');
+  position: relative;
+  border: 0;
+  @include u-border-bottom(1px);
+  @include u-border('base-light');
+}
+
+.jcc-expandable-item__excerpt {
+  @include u-bg('base-lightest');
+}
+
+.jcc-expandable-item__button {
+  all: inherit;
+  @include u-padding(3);
+  display: block;
+  width: 100%;
+}
+
+.jcc-expandable-item__content {
+  @include u-padding(3);
+  margin-left: 0;
+}
+
+.jcc-expandable-item__content[aria-hidden="true"] {
+  display: none;
+}
+
+// Temp style until we have the icon system in place
+.jcc-expandable-item__button:after {
+  position: absolute;
+  right: 24px;
+  top: 12px;
+  font-size: 2rem;
+  opacity: .3;
+}
+
+.jcc-expandable-item__button[aria-expanded="true"]:after {
+  content: "-";
+}
+
+.jcc-expandable-item__button[aria-expanded="false"]:after {
+  content: "+"; 
+}
+// End of temp styles

--- a/source/_patterns/02-molecules/interactive/expandable-item/expandable-item.js
+++ b/source/_patterns/02-molecules/interactive/expandable-item/expandable-item.js
@@ -1,0 +1,1 @@
+require("a11y-toggle");

--- a/source/_patterns/02-molecules/interactive/expandable-item/expandable-item.twig
+++ b/source/_patterns/02-molecules/interactive/expandable-item/expandable-item.twig
@@ -1,0 +1,9 @@
+<div class="jcc-expandable-item">
+  <dt class="jcc-expandable-item__excerpt"><button class="jcc-expandable-item__button" data-a11y-toggle="{{ id }}">
+    {{ excerpt }}
+  </button></dt>
+
+  <dd id="{{ id }}" class="jcc-expandable-item__content">
+    {{ content }}
+  </dd>
+</div>

--- a/source/_patterns/02-molecules/interactive/expandable-item/expandable-item.yml
+++ b/source/_patterns/02-molecules/interactive/expandable-item/expandable-item.yml
@@ -1,0 +1,3 @@
+id: 'section-001'
+excerpt: 'Section 2'
+content: 'If your bank account is levied, you must act quickly! You have only ten days from the date of the levy to file a claim of exempltion (plus five days if the notice was sent be mail) with the sheriff performing the levy.'

--- a/source/_patterns/03-organisms/sections/expandable-section/_expandable-section.scss
+++ b/source/_patterns/03-organisms/sections/expandable-section/_expandable-section.scss
@@ -1,0 +1,14 @@
+.jcc-expandable-section {
+
+}
+
+.jcc-expandable-section__header {
+  @include u-bg('base-lightest');
+  @include u-padding-y(5);
+  @include u-padding-x(3);
+}
+
+.jcc-expandable-section__content {
+  margin: 0;
+  
+}

--- a/source/_patterns/03-organisms/sections/expandable-section/expandable-section.twig
+++ b/source/_patterns/03-organisms/sections/expandable-section/expandable-section.twig
@@ -1,0 +1,20 @@
+<div class="jcc-expandable-section">
+  <div class="jcc-expandable-section__header">
+    {% include '@molecules/text/header-group/header-group.twig' with {
+      brow: headergroup.brow,
+      title: headergroup.title,
+      lead: headergroup.lead,
+      tag: headergroup.tag
+    } %}  
+  </div>
+
+  <dl class="jcc-expandable-section__content">
+    {% for item in content %}
+      {% include '@molecules/interactive/expandable-item/expandable-item.twig' with {
+        id: item.id,
+        excerpt: item.excerpt,
+        content: item.content
+      } %}        
+    {% endfor %}
+  </dl>
+</div>

--- a/source/_patterns/03-organisms/sections/expandable-section/expandable-section.yml
+++ b/source/_patterns/03-organisms/sections/expandable-section/expandable-section.yml
@@ -1,0 +1,18 @@
+headergroup:
+  brow: Expandable Section
+  title: "This is the Expandable Section"
+  lead: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aperiam dolorum consequuntur neque, amet, at asperiores quo inventore alias, qui nemo magni quaerat officiis. Odit soluta rem, sapiente consequuntur maxime adipisci!"
+content:
+  - id: 'section-001'
+    excerpt: 'Section 1'
+    content: 'If your bank account is levied, you must act quickly! You have only ten days from the date of the levy to file a claim of exempltion (plus five days if the notice was sent be mail) with the sheriff performing the levy.'
+  - id: 'section-002'
+    excerpt: 'Section 2'
+    content: 'If your bank account is levied, you must act quickly! You have only ten days from the date of the levy to file a claim of exempltion (plus five days if the notice was sent be mail) with the sheriff performing the levy.'
+  - id: 'section-003'
+    excerpt: 'Section 3'
+    content: 'If your bank account is levied, you must act quickly! You have only ten days from the date of the levy to file a claim of exempltion (plus five days if the notice was sent be mail) with the sheriff performing the levy.'
+  - id: 'section-004'
+    excerpt: 'Section 4'
+    content: 'If your bank account is levied, you must act quickly! You have only ten days from the date of the levy to file a claim of exempltion (plus five days if the notice was sent be mail) with the sheriff performing the levy.'
+


### PR DESCRIPTION
**Adds the Expandable Section**
We have two components for this. 

`expandable-item` | molecule | interactive 
Is a single item (`<dt> and <dd>`) of the definition list (`<dl>`). Also, implemented the toggle functionality using the `a11y-toggle` plugin, which is essentially identical to the [Collapsible Sections](https://inclusive-components.design/collapsible-sections/) article.

`expandable-section` | organism | section
Is the full section, including a `header-group` and remapping the `expandable-item` in a loop.
I didn't implement the `text-section` include here, due to the pushback we had on the modal. 
If this is not the same case, I agree we should implement the text-section as an include. 