### PR TITLE
Basic markup for the List-group

### DIFF
--- a/source/_patterns/02-molecules/blocks/list-group/_list-group.scss
+++ b/source/_patterns/02-molecules/blocks/list-group/_list-group.scss
@@ -18,10 +18,10 @@
   
 }
 
-.jcc-list-item__title {
-
+.jcc-list-item p {
+  @include u-text('base-light');
 }
 
-.jcc-list-item__excerpt {
-  @include u-text('base-light');
+.jcc-list-item p strong {
+  @include u-text('base');
 }

--- a/source/_patterns/02-molecules/blocks/list-group/_list-group.scss
+++ b/source/_patterns/02-molecules/blocks/list-group/_list-group.scss
@@ -1,0 +1,27 @@
+.jcc-list-group {
+
+}
+
+.jcc-list-group__container {
+
+}
+
+.jcc-list-group__item {
+
+}
+
+.jcc-list-group__item + .jcc-list-group__item {
+  @include u-padding-top(3);
+}
+
+.jcc-list-item {
+  
+}
+
+.jcc-list-item__title {
+
+}
+
+.jcc-list-item__excerpt {
+  @include u-text('base-light');
+}

--- a/source/_patterns/02-molecules/blocks/list-group/list-group.twig
+++ b/source/_patterns/02-molecules/blocks/list-group/list-group.twig
@@ -1,0 +1,12 @@
+<div class="jcc-list-group">
+  <ul class="jcc-list-group__container">
+    
+    {% for item in list_group %}
+    <li class="jcc-list-group__item jcc-list-item">
+      <p class="jcc-list-item__title">{{ item.title }}</p>
+      <p class="jcc-list-item__excerpt">{{ item.excerpt }}</p>
+    </li>
+    {% endfor %}
+    
+  </ul>
+</div>

--- a/source/_patterns/02-molecules/blocks/list-group/list-group.twig
+++ b/source/_patterns/02-molecules/blocks/list-group/list-group.twig
@@ -3,8 +3,8 @@
     
     {% for item in list_group %}
     <li class="jcc-list-group__item jcc-list-item">
-      <p class="jcc-list-item__title">{{ item.title }}</p>
-      <p class="jcc-list-item__excerpt">{{ item.excerpt }}</p>
+      <p><strong>{{ item.title }}</strong></p>
+      <p>{{ item.excerpt }}</p>
     </li>
     {% endfor %}
     

--- a/source/_patterns/02-molecules/blocks/list-group/list-group.yml
+++ b/source/_patterns/02-molecules/blocks/list-group/list-group.yml
@@ -1,0 +1,7 @@
+list_group:
+  - title: I never received the Summons and Complaint.
+    excerpt: You may be eligible to "set aside" the default judgement, or you might be able to negotiate a settlement with the debt collector.
+  - title: I didn't understand I needed to file a response.
+    excerpt: If you act quickly, you may be eligible to "set aside" the default judgement, or you might be able to negotiate a settlement with the debt collector.
+  - title: I didn't knowthere was a court case.
+    excerpt: Depending on the reasons, you may be eligible to "set aside" the default judgement, or you might be able to negotiate a settlement with the debt collector.    


### PR DESCRIPTION
Created the basic markup and structural CSS for the component. I left empty selectors for each element of the component in the scss file for quicker visual styling.