### PR TITLE
List block & Link list fixes

### DIFF
--- a/source/_patterns/02-molecules/blocks/link-list/link-list.twig
+++ b/source/_patterns/02-molecules/blocks/link-list/link-list.twig
@@ -1,9 +1,10 @@
 <div class="jcc-link-list {% if files_list %} jcc-link-list--files{% endif %}">
-  
+
   <ul class="jcc-link-list__list">
     {% for item in items %}
+      {% set url_attributes = item.url_attributes ? item.url_attributes : create_attribute() %}
       <li class="jcc-link-list__item">
-          
+
         {% if icon %}
         <span class="jcc-link-list__icon">
           {% include '@atoms/icons/icon.twig' with  {
@@ -14,7 +15,7 @@
           } %}
         </span>
         {% endif %}
-        {{item.name}} (<a{% if files_list %} download{% endif %} href="{{item.url}}" title="{{item.url_title}}">{{item.url_title}}</a>)
+        {{ item.name }} (<a{% if files_list %} download{% endif %} href="{{ item.url }}"{{ url_attributes }}>{{ item.url_title }}</a>)
       </li>
     {% endfor %}
   </ul>

--- a/source/_patterns/02-molecules/blocks/list-block/list-block.twig
+++ b/source/_patterns/02-molecules/blocks/list-block/list-block.twig
@@ -1,11 +1,13 @@
+{% set tag = tag|default('h2') %}
+
 <div class="jcc-list-block">
-  <h2 class="jcc-list-block__title">{{ title }}</h2>
+  {% if title %}
+    <{{ tag }} class="jcc-list-block__title">{{ title }}</{{ tag }}>
+  {% endif %}
+
   {% include '@molecules/blocks/link-list/link-list.twig' with {
     files_list: list.files_list,
-    items: list.items
+    items: list.items,
+    icon: list.icon
   } %}
-
 </div>
-
-
-


### PR DESCRIPTION
**Fixes:**

- Link list: Needs url attributes.
- Link list: `title` attributes that is exactly the same as text inside the `<a>` should not be used.
- List block: Heading element should be configurable.
- List block: `icon` variable (and anything nested as a general rule) needs to be explicitly passed.  
