### PR TITLE
Jump nav: Allow empty list.

### DIFF
--- a/source/_patterns/02-molecules/navigation/jump-nav/jump-nav.twig
+++ b/source/_patterns/02-molecules/navigation/jump-nav/jump-nav.twig
@@ -1,6 +1,6 @@
 {% set tag = tag|default('h2') %}
 
-{% if jump_nav|length > 0 %}
+{% if jump_nav|length > 0 or title %}
 <div class="jcc-jump-nav">
   <nav>
     <{{ tag }} class="jcc-jump-nav__title">{{ title }}</{{ tag }}>


### PR DESCRIPTION
I'm having to do this with JavaScript in Drupal now, and need the the empty list to print with title. It would make more sense to do this directly in Courtyard if we end up having time. For now, this will suffice.