### PR TITLE
Datefinder conditionals

### DIFF
--- a/source/_patterns/02-molecules/interactive/datefinder/datefinder.twig
+++ b/source/_patterns/02-molecules/interactive/datefinder/datefinder.twig
@@ -1,6 +1,7 @@
 <div class="jcc-datefinder">
   <h2 class="jcc-datefinder__title">{{ title }}</h2>
   <div class="jcc-datefinder__content">
+    {% if patternlab %}
     <form action="#" class="jcc-datefinder__form">
       <label for="filing_date" class="jcc-datefinder__label" title="{{ filing_date_label }}">{{ filing_date_label }}</label>
       {% include '@atoms/forms/date-input.twig' with  {
@@ -12,7 +13,10 @@
         error: date.error
       } %}
     </form>
-    <div class="jcc-datefinder__adjacent-dates">
+    {% else %}
+      {{ date_input }}
+    {% endif %}
+    <div class="jcc-datefinder__adjacent-dates" {{ serve_hidden ? "hidden=true" }}>
       <p class="jcc-datefinder__label">{{ serve_date_label }}</p>
       <span class="jcc-datefinder__icon">
         {% include '@atoms/icons/icon.twig' with  {
@@ -24,6 +28,7 @@
       </span>
       <p class="jcc-datefinder__date">{{ serve_date }}</p>
     </div>
+    {% if respond_date %}
     <div class="jcc-datefinder__adjacent-dates">
       <p class="jcc-datefinder__label">{{ respond_date_label }}</p>
       <span class="jcc-datefinder__icon">
@@ -36,5 +41,6 @@
       </span>
       <p class="jcc-datefinder__date">{{ respond_date }}</p>
     </div>
+    {% endif %}
   </div>
 </div>

--- a/source/_patterns/02-molecules/interactive/datefinder/datefinder.twig
+++ b/source/_patterns/02-molecules/interactive/datefinder/datefinder.twig
@@ -2,17 +2,17 @@
   <h2 class="jcc-datefinder__title">{{ title }}</h2>
   <div class="jcc-datefinder__content">
     {% if patternlab %}
-    <form action="#" class="jcc-datefinder__form">
-      <label for="filing_date" class="jcc-datefinder__label" title="{{ filing_date_label }}">{{ filing_date_label }}</label>
-      {% include '@atoms/forms/date-input.twig' with  {
-        title: date.title,
-        hint: date.hint,
-        month_label: date.month_label,
-        day_label: date.day_label,
-        year_label: date.year_label,
-        error: date.error
-      } %}
-    </form>
+      <form action="#" class="jcc-datefinder__form">
+        <label for="filing_date" class="jcc-datefinder__label" title="{{ filing_date_label }}">{{ filing_date_label }}</label>
+        {% include '@atoms/forms/date-input.twig' with  {
+          title: date.title,
+          hint: date.hint,
+          month_label: date.month_label,
+          day_label: date.day_label,
+          year_label: date.year_label,
+          error: date.error
+        } %}
+      </form>
     {% else %}
       {{ date_input }}
     {% endif %}
@@ -29,18 +29,18 @@
       <p class="jcc-datefinder__date">{{ serve_date }}</p>
     </div>
     {% if respond_date %}
-    <div class="jcc-datefinder__adjacent-dates">
-      <p class="jcc-datefinder__label">{{ respond_date_label }}</p>
-      <span class="jcc-datefinder__icon">
-        {% include '@atoms/icons/icon.twig' with  {
-            icon: reply_icon.icon,
-            title: reply_icon.title,
-            icon_file: reply_icon.icon_file,
-            decorative: reply_icon.decorative
-          } %}
-      </span>
-      <p class="jcc-datefinder__date">{{ respond_date }}</p>
-    </div>
+      <div class="jcc-datefinder__adjacent-dates">
+        <p class="jcc-datefinder__label">{{ respond_date_label }}</p>
+        <span class="jcc-datefinder__icon">
+          {% include '@atoms/icons/icon.twig' with  {
+              icon: reply_icon.icon,
+              title: reply_icon.title,
+              icon_file: reply_icon.icon_file,
+              decorative: reply_icon.decorative
+            } %}
+        </span>
+        <p class="jcc-datefinder__date">{{ respond_date }}</p>
+      </div>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
This pull request will allow for pattern library consumers to
- use of different input for the date (so it can be calculated from a Javascript Date object),
- hide the response by default (so it only appears when the date input is valid), and
- optional respond date.