### PR TITLE
Image rendering option needs to be in the image object.

### DIFF
--- a/source/_patterns/01-atoms/image/image.twig
+++ b/source/_patterns/01-atoms/image/image.twig
@@ -1,4 +1,6 @@
-{% if patternlab %}
+{% set renderer = image.renderer|default(patternlab) %}
+
+{% if renderer == 'patternlab' %}
   {% if image.src %}
     <img src="{{- image.src -}}"{% if image.alt %} alt="{{ image.alt }}"{% endif %} />
   {% endif %}


### PR DESCRIPTION
This is necessary in order to:

1.  Use the image component in cases where the image is located in Courtyard.
2. Have it work where images are nested without having to pass `patternlab` variable every time.

For example, with the Card section component.