### PR TITLE
Move call to php script from gulpfile.js to the composer.json post in…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
     "watch": "php core/console --watch",
     "start": "php core/console --server  --quiet & php core/console --watch",
     "post-install-cmd": [
-      "PatternLab\\Installer::postInstallCmd"
+      "PatternLab\\Installer::postInstallCmd",
+      "composer run generate"
     ],
     "post-update-cmd": [
       "PatternLab\\Installer::postUpdateCmd"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,11 +47,6 @@ const errorHandler = error => {
   this.emit("end");
 };
 
-// Use the Pattern Lab PHP command to generate the pattern library
-const plPhp = () => {
-  return exec("php core/console --generate");
-};
-
 const copyUswdsFonts = () => {
   return gulp.src(`${uswds}/fonts/**/*`).pipe(gulp.dest(config.fonts.public_fonts));
 };
@@ -175,7 +170,7 @@ const serve = cb => {
   });
 };
 
-const build = gulp.series(plPhp, copyUswdsFonts, copyUswdsImages, copyIconSprite, plCss, plJs);
+const build = gulp.series(copyUswdsFonts, copyUswdsImages, copyIconSprite, plCss, plJs);
 
 exports.build = build;
 exports.default = gulp.series(build, serve, watch);


### PR DESCRIPTION
[c3] Move call to php script from gulpfile.js to the composer.json post install.

Reasoning:

 - To keep different parts of the stack separate.
 - If building in a containerized environment with separate
 services for NodeJS and PHP, a JS script calling a PHP script will
 fail.<F6>
 - The Guilpfile.js build is not dependent on the output of the template
 generator, so there's no actual need to call it from there.

This does not affect the README or workflow.  You still run `composer
install` and the `npm install` in the same order... or any order I
guess.