### PR TITLE
form-lookup/all-forms: fix classnames

### DIFF
--- a/source/_patterns/05-pages/form-lookup/all-forms.js
+++ b/source/_patterns/05-pages/form-lookup/all-forms.js
@@ -2,7 +2,7 @@ import _ from "underscore";
 
 async function init() {
   console.log("all-forms init");
-  let formResults = document.querySelector(".form-results");
+  let formResults = document.querySelector(".jcc-forms-filter__form-results");
 
   let render = () => {
     formResults.innerHTML = forms.map(form => formResult(form)).join("\n");
@@ -10,9 +10,9 @@ async function init() {
 
   function formResult(form) {
     return `
-      <div class="form-result">
-        <a class="form-result-content" href="${form.url}" target="_blank">
-          <div class="form-number-and-title">
+      <div class="jcc-forms-filter__form-result">
+        <a class="jcc-forms-filter__form-result-content" href="${form.url}" target="_blank">
+          <div class="jcc-forms-filter__form-number-and-title">
             <div class="form-number">${form.id}</div>
             <div class="form-title">${form.title}</div>
           </div>

--- a/source/_patterns/05-pages/form-lookup/all-forms.twig
+++ b/source/_patterns/05-pages/form-lookup/all-forms.twig
@@ -7,10 +7,10 @@
     lead: '',
     body: '
       <p>Browse the list of all court forms, or <a class="text-white" href="../05-pages-form-lookup-form-lookup/05-pages-form-lookup-form-lookup.html">search by topic or form number</a></p>
-      <div class="search-results">
-        <div class="results-header">Forms</div>
-        <div class="form-results">
-          <div class="loading">...</div>
+      <div class="jcc-forms-filter__results-container">
+        <div class="jcc-forms-filter__results-header">Forms</div>
+        <div class="jcc-forms-filter__form-results">
+          <div class="jcc-forms-filter__loading">...</div>
         </div>
       </div>
     ',


### PR DESCRIPTION
I forgot to change the classnames on the all forms page when I changed them on the forms lookup page.