### PR TITLE
TC-178: Add third-level-menu-items.

### DIFF
--- a/source/_patterns/02-molecules/navigation/primary-nav/_primary-nav.scss
+++ b/source/_patterns/02-molecules/navigation/primary-nav/_primary-nav.scss
@@ -1,5 +1,10 @@
 @import "../../node_modules/slicknav/scss/slicknav.scss";
 
+// Hide slick nav display on desktop. There's an alternate.
+#slick-menu {
+  @include u-display(none);
+}
+
 .slicknav_menu {
   @include u-display(block);
 
@@ -109,12 +114,20 @@ nav.jcc-primary-nav {
     padding-right: 10%;
   }
   li {
+    & .jcc-primary-nav__sub-sub--item {
+      @include at-media(desktop) {
+        @include u-display(block);
+        width: 100%;
+        padding-left: 1.7em;
+      }
+    }
     @include u-display(block);
     padding: 0 70px;
     text-align: left;
     @include u-bg(primary-lighter);
     @include at-media(desktop) {
       @include u-display(inline-flex);
+      flex-direction: column;
       width: 33%;
       @include u-padding(1);
       @include u-bg(primary-dark);
@@ -146,7 +159,6 @@ nav.jcc-primary-nav {
         @include u-font-size("body", 7);
         @include u-text("bold");
         @include at-media(desktop) {
-          margin-bottom: 1em;
           padding: 0;
           &:hover {
             background-color: transparent;
@@ -176,7 +188,7 @@ nav.jcc-primary-nav {
         @include u-color("white");
         @include u-text("normal");
         @include u-font-size("body", 5);
-        margin-top: 10px;
+        margin-top: 1em;
         line-height: 1.4em;
         text-transform: capitalize;
         letter-spacing: 1px;

--- a/source/_patterns/02-molecules/navigation/primary-nav/primary-nav.twig
+++ b/source/_patterns/02-molecules/navigation/primary-nav/primary-nav.twig
@@ -6,43 +6,110 @@
       <div class="jcc-primary-nav__container">
         <button class="usa-nav__close"><img src="../../dist/img/close.svg" alt="close"></button>
         <ul id="slick-menu" class="usa-nav__primary usa-accordion">
-          {% for item in primary_nav.items %}
-            {% if item.sublinks %}
-              <li class="usa-nav__primary-item jcc-primary-nav__top_link">
-                <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-mega-nav-section-{{ item|length }}">
-                  <span>{{ item.name }}</span></button>
-                <div id="extended-mega-nav-section-{{ item|length }}" class="usa-nav__submenu usa-megamenu ">
-                  <div class="grid-row grid-gap-4">
-                    <div class="usa-col">
-                      <ul class="usa-nav__submenu-list jcc-primary-nav__sub">
-                        {% for i, sublink in item.sublinks %}
-                          <li class="jcc-primary-nav__sub--item">
-                            <a href="{{ item.sublinks[i].url }}">
-                              <div class="jcc-primary-nav__sub--title">
-                                {{ item.sublinks[i].name }}</div>
-                              <div class="jcc-primary-nav__sub--description">
-                                {{ item.sublinks[i].description }}
-                              </div>
-                            </a>
-                          </li>
-                        {% endfor %}
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </li>
-            {% else %}
-              <li class=" usa-nav__primary-item">
-                <a class="jcc-primary-nav__top_link" href="{{ item.url }}">
-                  <button class="usa-nav__link jcc-primary-nav__button-single" tabindex="-1">
-                    <span>{{ item.name }}</span>
-                  </button>
-                </a>
-              </li>
-            {% endif %}
-          {% endfor %}
+          {{ _self.slick_menu_links(primary_nav.items, 0) }}
+        </ul>
+        <ul class="usa-nav__primary usa-accordion">
+          {{ _self.menu_links(primary_nav.items, 0) }}
         </ul>
       </div>
     </nav>
   </header>
 </div>
+
+{% macro menu_links(items, menu_level) %}
+  {% for item in items %}
+    {% if menu_level == 0 %}
+      {% if item.sublinks %}
+        <li class="usa-nav__primary-item jcc-primary-nav__top_link">
+          <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-mega-nav-section-{{ item|length }}">
+            <span>{% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}</span>
+          </button>
+            <div id="extended-mega-nav-section-{{ item|length }}" class="usa-nav__submenu usa-megamenu ">
+              <div class="grid-row grid-gap-4">
+                <div class="usa-col">
+                  <ul class="usa-nav__submenu-list jcc-primary-nav__sub">
+                      {{ _self.menu_links(item.sublinks, menu_level + 1) }}
+                  </ul>
+                </div>
+              </div>
+            </div>
+        </li>
+      {% else %}
+        <li class=" usa-nav__primary-item">
+          <a class="jcc-primary-nav__top_link" href="{{ item.url }}">
+            <button class="usa-nav__link jcc-primary-nav__button-single" tabindex="-1">
+              <span>{% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}</span>
+            </button>
+          </a>
+        </li>
+      {% endif %}
+    {% elseif menu_level == 1 %}
+      <li class="jcc-primary-nav__sub--item">
+        <a href="{{ item.url }}">
+          <div class="jcc-primary-nav__sub--title">
+            {% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}
+          </div>
+          {% if item.description %}
+            <div class="jcc-primary-nav__sub--description">
+              {{ item.description }}
+            </div>
+          {% endif %}
+        </a>
+        {% if item.sublinks %}
+          <ul class="usa-nav__submenu-list jcc-primary-nav__sub--{{ menu_level }}">
+              {{ _self.menu_links(item.sublinks, menu_level + 1) }}
+          </ul>
+        {% endif %}
+      </li>
+    {% else %}
+      <li class="jcc-primary-nav__sub-sub--item sub-level-{{ menu_level }}">
+        <a href="{{ item.url }}">{% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}</a>
+      </li>
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
+{# Do not include level 3 links for slick menu. #}
+{% macro slick_menu_links(items, menu_level) %}
+  {% for item in items %}
+    {% if menu_level == 0 %}
+      {% if item.sublinks %}
+        <li class="usa-nav__primary-item jcc-primary-nav__top_link">
+          <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-mega-nav-section-{{ item|length }}">
+            <span>{% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}</span>
+          </button>
+            <div id="extended-mega-nav-section-{{ item|length }}" class="usa-nav__submenu usa-megamenu ">
+              <div class="grid-row grid-gap-4">
+                <div class="usa-col">
+                  <ul class="usa-nav__submenu-list jcc-primary-nav__sub">
+                      {{ _self.slick_menu_links(item.sublinks, menu_level + 1) }}
+                  </ul>
+                </div>
+              </div>
+            </div>
+        </li>
+      {% else %}
+        <li class=" usa-nav__primary-item">
+          <a class="jcc-primary-nav__top_link" href="{{ item.url }}">
+            <button class="usa-nav__link jcc-primary-nav__button-single" tabindex="-1">
+              <span>{% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}</span>
+            </button>
+          </a>
+        </li>
+      {% endif %}
+    {% elseif menu_level == 1 %}
+      <li class="jcc-primary-nav__sub--item">
+        <a href="{{ item.url }}">
+          <div class="jcc-primary-nav__sub--title">
+            {% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}
+          </div>
+          {% if item.description %}
+            <div class="jcc-primary-nav__sub--description">
+              {{ item.description }}
+            </div>
+          {% endif %}
+        </a>
+      </li>
+    {% endif %}
+  {% endfor %}
+{% endmacro %}

--- a/source/_patterns/02-molecules/navigation/primary-nav/primary-nav.twig
+++ b/source/_patterns/02-molecules/navigation/primary-nav/primary-nav.twig
@@ -6,17 +6,17 @@
       <div class="jcc-primary-nav__container">
         <button class="usa-nav__close"><img src="../../dist/img/close.svg" alt="close"></button>
         <ul id="slick-menu" class="usa-nav__primary usa-accordion">
-          {{ _self.slick_menu_links(primary_nav.items, 0) }}
+          {{ _self.menu_links(primary_nav.items, 0, true) }}
         </ul>
         <ul class="usa-nav__primary usa-accordion">
-          {{ _self.menu_links(primary_nav.items, 0) }}
+          {{ _self.menu_links(primary_nav.items, 0, false) }}
         </ul>
       </div>
     </nav>
   </header>
 </div>
 
-{% macro menu_links(items, menu_level) %}
+{% macro menu_links(items, menu_level, slick) %}
   {% for item in items %}
     {% if menu_level == 0 %}
       {% if item.sublinks %}
@@ -28,7 +28,7 @@
               <div class="grid-row grid-gap-4">
                 <div class="usa-col">
                   <ul class="usa-nav__submenu-list jcc-primary-nav__sub">
-                      {{ _self.menu_links(item.sublinks, menu_level + 1) }}
+                      {{ _self.menu_links(item.sublinks, menu_level + 1, slick) }}
                   </ul>
                 </div>
               </div>
@@ -55,60 +55,15 @@
             </div>
           {% endif %}
         </a>
-        {% if item.sublinks %}
+        {% if item.sublinks and not slick %}
           <ul class="usa-nav__submenu-list jcc-primary-nav__sub--{{ menu_level }}">
-              {{ _self.menu_links(item.sublinks, menu_level + 1) }}
+              {{ _self.menu_links(item.sublinks, menu_level + 1, slick) }}
           </ul>
         {% endif %}
       </li>
-    {% else %}
+    {% elseif not slick %}
       <li class="jcc-primary-nav__sub-sub--item sub-level-{{ menu_level }}">
         <a href="{{ item.url }}">{% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}</a>
-      </li>
-    {% endif %}
-  {% endfor %}
-{% endmacro %}
-
-{# Do not include level 3 links for slick menu. #}
-{% macro slick_menu_links(items, menu_level) %}
-  {% for item in items %}
-    {% if menu_level == 0 %}
-      {% if item.sublinks %}
-        <li class="usa-nav__primary-item jcc-primary-nav__top_link">
-          <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="extended-mega-nav-section-{{ item|length }}">
-            <span>{% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}</span>
-          </button>
-            <div id="extended-mega-nav-section-{{ item|length }}" class="usa-nav__submenu usa-megamenu ">
-              <div class="grid-row grid-gap-4">
-                <div class="usa-col">
-                  <ul class="usa-nav__submenu-list jcc-primary-nav__sub">
-                      {{ _self.slick_menu_links(item.sublinks, menu_level + 1) }}
-                  </ul>
-                </div>
-              </div>
-            </div>
-        </li>
-      {% else %}
-        <li class=" usa-nav__primary-item">
-          <a class="jcc-primary-nav__top_link" href="{{ item.url }}">
-            <button class="usa-nav__link jcc-primary-nav__button-single" tabindex="-1">
-              <span>{% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}</span>
-            </button>
-          </a>
-        </li>
-      {% endif %}
-    {% elseif menu_level == 1 %}
-      <li class="jcc-primary-nav__sub--item">
-        <a href="{{ item.url }}">
-          <div class="jcc-primary-nav__sub--title">
-            {% if item.icon %}{{ item.icon }}{% endif %} {{ item.name }}
-          </div>
-          {% if item.description %}
-            <div class="jcc-primary-nav__sub--description">
-              {{ item.description }}
-            </div>
-          {% endif %}
-        </a>
       </li>
     {% endif %}
   {% endfor %}

--- a/source/_patterns/02-molecules/navigation/primary-nav/primary-nav.yml
+++ b/source/_patterns/02-molecules/navigation/primary-nav/primary-nav.yml
@@ -5,7 +5,7 @@ primary_nav:
       number: "one"
       sublinks:
         - name: "Case Calendar"
-          description: Short Description about what the landing page."
+          description: "Short Description about what the landing page."
           url: "#"
         - name: "Case Query"
           description: "Short Description about what the landing page. Could be a variable length, who knows what this will say."
@@ -56,6 +56,15 @@ primary_nav:
     - name: "General Information"
       url: "#"
       sublinks:
+        - name: "ADA"
+          url: "#"
+          icon: "<i class='fas fa-universal-access'></i>"
+          sublinks:
+            - name: "Sign Language Interpreters"
+              icon: "<i class='fas fa-american-sign-language-interpreting'></i>"
+              url: "#"
+            - name: "Accomodations"
+              url: "#"
         - name: "Annulment"
           description: "Short Description about what the landing page. Could be a variable length, who knows what this will say."
           url: "#"
@@ -83,3 +92,4 @@ primary_nav:
         - name: "Step-parent Adoptions"
           description: "Short Description about what the landing page. Could be a variable length, who knows what this will say."
           url: "#"
+

--- a/source/_patterns/03-organisms/global/header-trial/header-trial.yml
+++ b/source/_patterns/03-organisms/global/header-trial/header-trial.yml
@@ -27,7 +27,7 @@ header_trial:
         number: "one"
         sublinks:
           - name: "Case Calendar"
-            description: Short Description about what the landing page."
+            description: "Short Description about what the landing page."
             url: "#"
           - name: "Case Query"
             description: "Short Description about what the landing page. Could be a variable length, who knows what this will say."
@@ -78,6 +78,15 @@ header_trial:
       - name: "General Information"
         url: "#"
         sublinks:
+          - name: "ADA"
+            url: "#"
+            icon: "<i class='fas fa-universal-access'></i>"
+            sublinks:
+              - name: "Sign Language Interpreters"
+                icon: "<i class='fas fa-american-sign-language-interpreting'></i>"
+                url: "#"
+              - name: "Accomodations"
+                url: "#"
           - name: "Annulment"
             description: "Short Description about what the landing page. Could be a variable length, who knows what this will say."
             url: "#"


### PR DESCRIPTION
Using macro to iterate over nested menu items. Using a condition variable for slick nav version of the menu to not include 3rd level on mobile. Slick nav wasn't handling it well and this seemed to be the easiest/only way to override it.
    
Adds support for icons ahead of link names.