### PR TITLE
SRL-198 Change switchboard body to use <div> instead of <p>

### DIFF
--- a/source/_patterns/03-organisms/sections/switchboard/switchboard.twig
+++ b/source/_patterns/03-organisms/sections/switchboard/switchboard.twig
@@ -19,9 +19,9 @@
             } %}
           {% endif %}
           {% if switchboard.body %}
-            <p class="jcc-switchboard__body">
+            <div class="jcc-switchboard__body">
               {{ switchboard.body }}
-            </p>
+            </div>
           {% endif %}
         </div>
         <div class="jcc-switchboard__column-right">


### PR DESCRIPTION
JCC wants to be able to use the full WYSIWYG in the switchboard.body field.