### PR TITLE
hotfix/WSGEN-1080--mobile-logo-not-linking-to-home

### DIFF
--- a/source/_patterns/03-organisms/global/header-trial/header-trial.twig
+++ b/source/_patterns/03-organisms/global/header-trial/header-trial.twig
@@ -14,9 +14,11 @@
   <div class="mobile">
     <div class="jcc--header__mobile-container">
       <div class="jcc-header__logo">
+        <a href="{{ header_trial.header_topbar.home_url|default('/') }}">
         {% include '@atoms/icons/logo.twig' with {
           logo : header_trial.mobile.logo
         } %}
+        </a>
       </div>
       {# BEGIN search function #}
       <div class="buttons slicknav">


### PR DESCRIPTION
Fix the lack of home page link in mobile version for logo.