### PR TITLE
Update accordion.twig

### DIFF
--- a/source/_patterns/03-organisms/accordion/accordion.twig
+++ b/source/_patterns/03-organisms/accordion/accordion.twig
@@ -32,7 +32,7 @@
       </{{ tag }}>
 
       <div class="usa-accordion__content usa-prose" id="{{ id }}">
-        {{- item.body|raw -}}
+        {{- item.body -}}
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
We shouldn't need `|raw` on anything.  We should make sure Drupal renders content properly with filters for safety.

I populate the body like this, which works fine without `|raw` and respects the text format:

```
    body: {
      '#type': 'processed_text',
      '#text': item['#paragraph'].field_text.value,
      '#format': item['#paragraph'].field_text.format
    },
```