### PR TITLE
Use full @ path for global-bar.twig

### DIFF
--- a/source/_patterns/03-organisms/global/footer.twig
+++ b/source/_patterns/03-organisms/global/footer.twig
@@ -86,7 +86,7 @@
   </div>
 
   <div class="jcc-footer__shoe-section">
-    {% include "global-bar.twig" with {
+    {% include "@organisms/global/global-bar.twig" with {
       global_bar: footer.shoe
     } %}
 


### PR DESCRIPTION
Just using the path doesn't seem to work with Drupal components.