### PR TITLE
Use full @ path for global-bar.twig

### DIFF
--- a/source/_patterns/03-organisms/global/header.twig
+++ b/source/_patterns/03-organisms/global/header.twig
@@ -34,7 +34,7 @@
 <header class="{{ classes|join(' ')|trim }}">
 
   <div class="jcc-header__hat">
-    {% include 'global-bar.twig' with {
+    {% include '@organisms/global/global-bar.twig' with {
       global_bar: header.hat
     } %}
   </div>


### PR DESCRIPTION
relative path doesn't seem to work with Drupal components.