### PR TITLE
WSGEN-1051: adjusting base footer to support content blocks

### DIFF
--- a/source/_patterns/03-organisms/global/footer-base/footer-base.twig
+++ b/source/_patterns/03-organisms/global/footer-base/footer-base.twig
@@ -26,6 +26,8 @@
                               <li class="usa-footer__secondary-link"><a href="{{ child.href }}">{{ child.text }}</a></li>
                             {% endfor %}
                           </ul>
+                        {% elseif link.block %}
+                          {{ link.block }}
                         {% endif %}
                       </section>
                     </div>
@@ -84,9 +86,10 @@
         </div>
       </div>
     </div>
+  </div>
 
-    {% include '@molecules/navigation/global-bar/global-bar.twig' with {
-      global_bar: footer_base.global_bar,
-      is_footer: true
-    } %}
+  {% include '@molecules/navigation/global-bar/global-bar.twig' with {
+    global_bar: footer_base.global_bar,
+    is_footer: true
+  } %}
 </footer>

--- a/source/_patterns/03-organisms/global/footer-base/footer-base.yml
+++ b/source/_patterns/03-organisms/global/footer-base/footer-base.yml
@@ -11,6 +11,7 @@ footer_base:
       href: "#"
     - text: Simple link 3
       href: "#"
+    - block: #content or feature alternative rather than a simple listing, text title optional
   secondary_menu_cols: '3'
   social_links:
     items:

--- a/source/_patterns/03-organisms/global/footer-base/footer-base~big-with-block-option.yml
+++ b/source/_patterns/03-organisms/global/footer-base/footer-base~big-with-block-option.yml
@@ -1,6 +1,5 @@
 footer_base:
   height_variant: 'big'
-  background_variant: 'inverted'
   links:
     - text: Nested section 1
       links:
@@ -34,3 +33,5 @@ footer_base:
           href: "#"
         - text: Navigation link 12
           href: "#"
+    - text: Subscribe with your email address to receive news and updates
+      block: '<div><input id="input-type-text" class="usa-input margin-bottom-2" name="input-type-text" type="text"><button class="usa-button ">Sign Up</button></div>'

--- a/source/_patterns/03-organisms/global/footer-base/footer-base~big.yml
+++ b/source/_patterns/03-organisms/global/footer-base/footer-base~big.yml
@@ -13,7 +13,6 @@ footer_base:
           href: "#"
         - text: A very long navigation link that goes onto two lines
           href: "#"
-          href: "#"
     - text: Nested section 2
       links:
         - text: Navigation link 5
@@ -25,4 +24,12 @@ footer_base:
         - text: Navigation link 8
           href: "#"
     - text: Simple link 1
-      href: "#"
+      links:
+        - text: Navigation link 9
+          href: "#"
+        - text: Navigation link 10
+          href: "#"
+        - text: Navigation link 11
+          href: "#"
+        - text: Navigation link 12
+          href: "#"


### PR DESCRIPTION
Need to be able to move subscription feature to footer base next to links. Any concerns with the approach that I am taking to create that variant to allow either a list of links or a block of content?