### PR TITLE
TCI-470: Borderless card- Adding underline on hover

### DIFF
--- a/source/_patterns/02-molecules/card/_card.scss
+++ b/source/_patterns/02-molecules/card/_card.scss
@@ -55,6 +55,11 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
     @include u-padding-right(3);
     @include u-border-width(0);
     @include u-bg("transparent");
+
+    .usa-card__heading a:hover {
+      @include u-text-decoration(underline);
+      text-decoration-thickness: 2px;
+    }
   }
 
   .usa-card--media-left & {


### PR DESCRIPTION
Adding the underline to borderless card heading links.