### PR TITLE
TCI-417: Fixing external link icon to hero text

### DIFF
--- a/source/_patterns/02-molecules/hero/_hero.scss
+++ b/source/_patterns/02-molecules/hero/_hero.scss
@@ -71,6 +71,15 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
 
   .jcc-hero--background-alt & {
     @include u-color(map-get($_config, alt-background-text));
+    @include text-color(map-get($_config, alt-background-text));
+  }
+
+  &.usa-prose a.ext {
+    &::after {
+      .jcc-hero--background-alt & {
+        @include u-bg(map-get($_config, alt-background-text));
+      }
+    }
   }
 }
 
@@ -114,6 +123,14 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
 
   .jcc-hero--background-alt & {
     @include text-color(map-get($_config, alt-background-text));
+  }
+
+  &.usa-prose a.ext {
+    &::after {
+      .jcc-hero--background-alt & {
+        @include u-bg(map-get($_config, alt-background-text));
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fixing text color and icon background color to alternative hero. The .usa-prose class is needed to get precedence over other rules defining the colors. 