### PR TITLE
TCI-519: Overwriting table text wrap

### DIFF
--- a/source/_patterns/02-molecules/body/_body.scss
+++ b/source/_patterns/02-molecules/body/_body.scss
@@ -9,6 +9,10 @@
   @include at-media(desktop) {
     @include grid-col(8);
   }
+
+  .usa-table td {
+    white-space: normal;
+  }
 }
 
 .jcc-body__main-text {


### PR DESCRIPTION
Overwriting white-space property to support horizontal scroll just when the table is bigger than the screen.