### PR TITLE
TCI-511: Fix button attributes strange behavior on Drupal

### DIFF
--- a/source/_patterns/01-atoms/button/button.twig
+++ b/source/_patterns/01-atoms/button/button.twig
@@ -31,18 +31,14 @@
   button.icon_layout ? 'jcc-button--icon-' ~ button.icon_layout : ''
 ]|merge(button.classes|default([''])) %}
 
-{% set attributes =
-  attributes.addClass(classes) ~
-  attributes.setAttribute('aria_label', button.aria_label) ~
-  button.other_attributes
-%}
+{% set attributes = attributes.addClass(classes) %}
 
 {% if button.type == 'button' %}
-  <button {{ attributes }}>
+  <button {{ attributes }} {{ button.other_attributes }} >
     {{- button.text -}}
   </button>
 {% else %}
-  <a {{ attributes }} href="{{ button.url }}">
+  <a {{ attributes }} {{ button.other_attributes }} href="{{ button.url }}">
     <span class="jcc-button__text{{ button.icon ? '--with-icon' : '' }}">{{- button.text -}}</span>
 
     {% if button.is_external %}


### PR DESCRIPTION
Little refactor of attributes on button atom. The current one is causing strange string behavior on Drupal buttons (offset component). Aria label is already set on lines 23-25 and the "button.other_attributes" is been added outside "attributes" when applicable. 