### PR TITLE
TCI-561: Changing table fix to section styles

### DIFF
--- a/source/_patterns/02-molecules/body/_body.scss
+++ b/source/_patterns/02-molecules/body/_body.scss
@@ -10,10 +10,6 @@
     @include grid-col(8);
   }
 
-  .usa-table td {
-    white-space: normal;
-  }
-
   .align-left {
     @include u-float(left);
     @include u-margin-right(3);

--- a/source/_patterns/02-molecules/section/_section.scss
+++ b/source/_patterns/02-molecules/section/_section.scss
@@ -30,6 +30,11 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
 .jcc-section--container {
   .jcc-section__inner {
     @include grid-container(widescreen);
+
+    // Adding table trick to avoid overflow in any section
+    .usa-table td {
+      white-space: normal;
+    }
   }
 }
 


### PR DESCRIPTION
Table is not an actual component on the courtyard patternlab, so the workaround to fix the overflow (USWDS doesn't have a setting for this) is looking at the best place to put the property, Section could be the "fix any" instead of using body__main.