### PR TITLE
TCI-726: update hero button box shadow

### DIFF
--- a/source/_patterns/02-molecules/hero/_hero-tiles.scss
+++ b/source/_patterns/02-molecules/hero/_hero-tiles.scss
@@ -70,7 +70,7 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
     @include u-color("white");
     @include u-text-decoration(no-underline);
     height: 110px;
-    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
 
     @include at-media(tablet) {
       @include u-justify-content(justify-center);


### PR DESCRIPTION
# Pull Request

Closes Issue #TCI-726

## Issue Description

Revise the box shadow value for Hero Grid Buttons.

## Summary of Changes

- Change the value of the box shadow from `box-shadow: 0 3px 10px rgba(0, 0, 0, 0.25);` => `box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);`

## Testing Instructions

- Visit Pattern Lab
- Navigate to Molecules/Hero Titles
- [ ] The box shadow is updated
- [ ] The box shadow change satisfies design request
