### PR TITLE
TCI-727: specify the color on hover

### DIFF
--- a/source/_patterns/03-organisms/global/_header.scss
+++ b/source/_patterns/03-organisms/global/_header.scss
@@ -411,6 +411,7 @@ $_hat: map-get($_config, hat);
 
         &:hover {
           @include hc(background-color, $_nav, sub-sub-background);
+          @include hc(color, $_translate, text-hover);
           @include u-text-decoration(no-underline);
         }
       }


### PR DESCRIPTION
# Pull Request

Closes Issue #TCI-727

## Issue Description

Specify hover state for nav links in header.

## Summary of Changes

- Specifically set the `color` property of hovered links in the header to white from translate map.

## Testing Instructions

- Visit Pattern Lab
- Navigate to Organisms/General/Header
- View sm-md breakpoints
- [ ] Are the nested submenu items correctly appearing with a white hover state?