### PR TITLE
TCI-725 :: Reduce Vertical Spacing

### DIFF
--- a/source/_patterns/02-molecules/section/_section.scss
+++ b/source/_patterns/02-molecules/section/_section.scss
@@ -1,12 +1,15 @@
 $_config_schemes: (
   base: (
+    padding-top: 9,
     alt-background: $theme-color-base-lightest,
     alt-background-border: 0,
     alt-background-border-color: "transparent",
     alt-margin-top: 10,
     subsection-section-padding: 4,
   ),
-  local: (),
+  local: (
+    padding-top: 5,
+  ),
   pro: (
     alt-background: "gray-1",
     alt-background-border: 1px,
@@ -19,7 +22,7 @@ $_config_schemes: (
 $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
 
 .jcc-section {
-  @include u-padding-top(5);
+  @include u-padding-top(map-get($_config, padding-top));
 
   .jcc-section {
     &:first-of-type {

--- a/source/_patterns/02-molecules/section/_section.scss
+++ b/source/_patterns/02-molecules/section/_section.scss
@@ -8,7 +8,7 @@ $_config_schemes: (
     subsection-section-padding: 4,
   ),
   local: (
-    padding-top: 5,
+    padding-top: 6,
   ),
   pro: (
     alt-background: "gray-1",

--- a/source/_patterns/02-molecules/section/_section.scss
+++ b/source/_patterns/02-molecules/section/_section.scss
@@ -19,7 +19,7 @@ $_config_schemes: (
 $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
 
 .jcc-section {
-  @include u-padding-top(9);
+  @include u-padding-top(6);
 
   .jcc-section {
     &:first-of-type {

--- a/source/_patterns/02-molecules/section/_section.scss
+++ b/source/_patterns/02-molecules/section/_section.scss
@@ -19,7 +19,7 @@ $_config_schemes: (
 $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
 
 .jcc-section {
-  @include u-padding-top(6);
+  @include u-padding-top(5);
 
   .jcc-section {
     &:first-of-type {


### PR DESCRIPTION
# Pull Request

Closes Issue #TCI-725

## Issue Description

Reduce the vertical spacing on components.

## Summary of Changes

- Adjust the spacing class on `.jcc-section` from the 9th spacer to the 6th.

## Testing Instructions

- Visit Pattern Lab on 2.x-dev
- [ ] Is the top spacing for components reduced?