### PR TITLE
TCI-684 :: Constrain Body Text without an Aside

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# Pull Request
+
+Closes Issue #X
+
+<!--
+These markdown comments are for description only. They can be deleted. 
+
+The audience for this document are developers.
+
+Please submit pull requests against the 2.x-dev branch.
+-->
+
+## Issue Description
+
+<!--
+Describe what problem you're solving. Link the issue from the issues tab.
+-->
+
+## Summary of Changes
+
+<!--
+How did you solve the problem? Did you update any documentation this affected?
+-->
+
+## Testing Instructions
+
+<!--
+How can I confirm that this work was done and done accurately? What should I expect to see?
+-->

--- a/source/_patterns/02-molecules/body/_body.scss
+++ b/source/_patterns/02-molecules/body/_body.scss
@@ -41,8 +41,9 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
       @include grid-col(12);
     }
 
+    .jcc-section-heading__lead,
     .jcc-body__main-text {
-      @include grid-col(8);
+      @include u-measure(6);
     }
 
   }

--- a/source/_patterns/02-molecules/body/_body.scss
+++ b/source/_patterns/02-molecules/body/_body.scss
@@ -40,6 +40,12 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
     @include at-media(desktop) {
       @include grid-col(12);
     }
+
+    .jcc-body__main-text {
+      @include grid-col(8);
+    }
+
+
   }
 }
 

--- a/source/_patterns/02-molecules/body/_body.scss
+++ b/source/_patterns/02-molecules/body/_body.scss
@@ -45,7 +45,6 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
       @include grid-col(8);
     }
 
-
   }
 }
 


### PR DESCRIPTION
# Pull Request

Closes Issue #TCI-684

## Issue Description

The body size for body text without an aside is also reduced to approximately 800px.

A PR template has been included here as well.

## Summary of Changes

* Add CSS to reduce the body text of the main text section only. The title should remain full width.

## Testing Instructions

* Visit the Interior Page on the [Pattern Library](http://patternlab.courts.ca.gov/2.x-dev/public/?p=pages-interior-example)
* View the Body Component at the bottom of the page
* This component has a constrained width on desktop
* This component remains full width on small screens