### PR TITLE
TCI-695 :: Accordion Condensed Width

### DIFF
--- a/source/_patterns/03-organisms/accordion/_accordion.scss
+++ b/source/_patterns/03-organisms/accordion/_accordion.scss
@@ -28,7 +28,7 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
   }
 }
 
-.jcc-section--container{
+.jcc-section--container {
   .usa-accordion__button {
     @include u-text(map-get($_config, button-font-color));
     @include u-border-bottom("2px", solid, map-get($_config, border-bottom-color));
@@ -59,4 +59,13 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
     }
   }
 
+}
+
+// Override the max-width for inner-content.
+.usa-accordion__content {
+  .usa-accordion--condensed & {
+    @include at-media(desktop) {
+      @include u-measure(6);
+    }
+  }
 }

--- a/source/_patterns/03-organisms/accordion/accordion.twig
+++ b/source/_patterns/03-organisms/accordion/accordion.twig
@@ -2,6 +2,7 @@
 /**
  * Available variables:
  * - accordion - primary variable
+ *   - style: general style of accordion [full, condensed]
  *   - collapse_first: boolean - collapse the first item on load?
  *   - heading: the heading (title & lead)
  *   - items: array of accordion items
@@ -14,9 +15,11 @@
 
 {% set tag = accordion.item_tag|default('h3') %}
 {% set collapse_first = accordion.collapse_first|default(false) %}
+{% set style = accordion.style|default('condensed') %}
 
 {% set classes = [
   'usa-accordion',
+  'usa-accordion--' ~ style,
 ]|merge(accordion.classes|default([])) %}
 
 {% set content %}

--- a/source/_patterns/03-organisms/accordion/accordion.yml
+++ b/source/_patterns/03-organisms/accordion/accordion.yml
@@ -1,4 +1,5 @@
 accordion:
+  style: "full"
   heading:
     title: "Accordion"
   items:

--- a/source/_patterns/03-organisms/accordion/accordion~condensed.yml
+++ b/source/_patterns/03-organisms/accordion/accordion~condensed.yml
@@ -1,0 +1,2 @@
+accordion:
+  style: 'condensed'


### PR DESCRIPTION
# Pull Request

Closes Issue #TCI-695

## Issue Description

Set a new variant for condensed width accordions.

## Summary of Changes

* Add new style variant `condensed`
* Update Twig component
* Update Sass

## Testing Instructions

- Visit 2.x-dev Pattern Library
- Are there two variants for full and condensed?
- Is the condensed width variant approximately 800px?