### PR TITLE
TCI-831 :: Header/Footer Content Width

### DIFF
--- a/source/_patterns/03-organisms/global/_footer.scss
+++ b/source/_patterns/03-organisms/global/_footer.scss
@@ -178,7 +178,7 @@ $_shoe: map-get($_config, shoe);
 
 .usa-footer__logo {
   @include at-media(desktop) {
-    @include grid-col(9);
+    @include grid-col(12);
   }
 }
 

--- a/source/_patterns/03-organisms/global/_global-bar.scss
+++ b/source/_patterns/03-organisms/global/_global-bar.scss
@@ -49,7 +49,7 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
 
   @include at-media(desktop) {
     @include u-text-align(left);
-    flex: 1 0 auto;
+    width: 40%;
   }
 }
 
@@ -58,6 +58,7 @@ $_config: map-merge-by-keys($_config_schemes, base, $_config_schemes, $scheme);
 
   @include at-media(desktop) {
     @include grid-col();
+    width: 60%;
   }
 }
 


### PR DESCRIPTION
# Pull Request

Closes Issue #TCI-831

## Issue Description

Content in header and footer not line breaking as desired.

## Summary of Changes

- Adjust Global Bar to have widths for logo/links
- Adjust Footer to allow full 12 grid width

## Testing Instructions

- Visit PL
- Visit Homepage
- View Header "hat" area, does the text break well?
- View Footer "shoe" area, does the text break well?
- Does the site name if the footer show full width on large screens?